### PR TITLE
Put a small sleep in the timer function else case

### DIFF
--- a/freshroastsr700/__init__.py
+++ b/freshroastsr700/__init__.py
@@ -220,6 +220,8 @@ class freshroastsr700(object):
                         self.state_transition_func()
                     else:
                         self.idle()
+            else:
+                time.sleep(0.01)
 
     def get_roaster_state(self):
         """Returns a string based upon the current state of the roaster. Will


### PR DESCRIPTION
To prevent high CPU usage, adding a small sleep in the else logic.

This should also alleviate some UI lag issues in Openroast once you plug the roaster in. I found that the tight loop in the timer thread was taking so much CPU that the UI responsiveness would drop to about one second for a click on my machine.
