### PR TITLE
Adds support for python 2.7.

### DIFF
--- a/freshroastsr700/utils.py
+++ b/freshroastsr700/utils.py
@@ -30,6 +30,6 @@ def seconds_to_float(time_in_seconds):
     """Converts seconds to float rounded to one digit. Will cap the float at
     9.9 or 594 seconds."""
     if(time_in_seconds <= 594):
-        return round((time_in_seconds / 60), 1)
+        return round((float(time_in_seconds) / 60.0), 1)
 
     return 9.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+# This flag says that the code is written to work on both Python 2 and Python
+# 3. If at all possible, it is good practice to do this. If you cannot, you
+# will need to generate wheels for each Python version that you support.
+universal=1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,4 @@ coveralls
 sphinx
 sphinx-autobuild
 sphinx_rtd_theme
+mock

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,10 @@
 # Made available under the MIT license.
 
 import unittest
-from unittest import mock
-
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from freshroastsr700 import utils
 from freshroastsr700 import exceptions
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py34, py35
+envlist = py27, py34, py35
 skip_missing_interpreters = True
 skipsdist = True
 usedevelop = True


### PR DESCRIPTION
Modified implementation to add python 2.7 support.  These modifications enable freshroastrc700 module to run in python 2.7+.  Tests executed successfully for python 2.7 and 3.4.  Tox.ini modified to add python 2.7 testing.

__init__.py
=========
I removed the dependencies on int.to_bytes and int.from_bytes, changing those to struct.pack and struct.unpack calls.  For this I need to import struct.

I added debug-level logging on all reads and writes, and imported binascii to do so.  In doing this, I decided to remove an info-level logging of read packets, as it became redundant.

In _read_existing_recipe(), I found that with an SR700 straight out of the box, purchased Dec 2016, _initialize() would almost always hit an infinite loop condition because the device went straight to replying with '00' flag byte in packets (rather than the documented sequence of A0, AA and finally AF packets).  Adding a check for '00' seems to have resolved this issue in my testing.

At line 303, I decided to be consistent with the following lines by fetching the time_remaining property using the _{var}.value approach.  I did this due to problems I was having with utils.seconds_to_float() in python 2.7, which would always return 0.  I ended up leaving the change in for observed consistency, although this was not the cause of the issue with utils.seconds_to_float().

utils.py
=====
In order to get this to display the 'decimal minutes' properly on the SR700 in python 2.7, I had to make the suggested changes.

setup.cfg
=======
With the addition of python 2.7 support, the module is now 'universal' and can be packaged as such, hence the setup.cfg file.

test-requirements.txt
================
I added mock as a dependency.  mock was backported as an independent module for python 2.7.

tox.ini
=====
Added testing for python 2.7 interpreter, in addition to 3.4 and 3.5. 

Tox testing passed on python 2.7 and python 3.4 on my ubuntu 14.04 laptop.

 