### PR TITLE
Updated travis to deploy to pypi.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,19 @@
 language: python
+
 install:
-  - pip install tox 
+  - pip install -r test-requirements.txt
+
 script:
   - tox
+
+deploy:
+  provider: pypi
+  user: lodge93
+  distributions: sdist bdist_wheel
+  password:
+    secure: ZcQFG96IscAHWJsMw8PNtbBBE7udUoAD4IXArYGeMM1FyNxFG2wYXXIbaxSMrHfQ2wxEXXsUxXRyg7H7moOTBsvs71XzIkTkY6nvjFJxB0E8y/VziINvqbXLtz0UbbWE97KLc9otJTOlfwHgKiCLzOMH5rmsioyZd3wtJaiQ/EDq+uiVcsPR/HtLGlsQmn6m61NZTBQKA1ksHQP4IiuT4gOunSMQzso1JKXuv7Ivgoyi9CJECJsOMpPfWdBqup4jnlMr0ZzLxp0w11LLk4eueY+MYWJ6hDM3wEL7gXPCGVNyvp0yjW1iJUR+3cw5gl5SigxPTpGybd5XxBVda/uP1tmRpUdloxCw1CV+Wssl3bovmaLM+AbHa2eLLoW6K5RRZosrJ94FPC9i+VmlSdm3+WiHp6iAvgiCxWwwtYBCW7TNg8VLgFpKkPlMlbzU4SgIZvkp6OAcmEmFRSF46f004frIS6SAGCypyShYkYbr+J4BhCsrEVW/i8u7wKLz93qVLux4u1eao8g1Cu/WIVI9Bii0fbsFQ9y3L3TgyehS1D3N1Jij8aDHxGugVYnKffnZY7NfiFUjxfZLvEyc47bNCwuwtNoIwSmDjfSds59j0+Eg7rac1L0+HLL5YKt9PH1pv9+N044teReOEFeyJyufu5/Uqby+mk9akuZIapcjECM=
+  on:
+    tags: true
+
 after_success:
   - coveralls


### PR DESCRIPTION
This will allow us to deploy to pypi without having to manually package and
push the project. This step will only run for tagged commits. Github will
automatically tag commits when a release is made, so releases will be
built automatically.