### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
 
-before_install:
-  # work around https://github.com/travis-ci/travis-ci/issues/8363
-  - pyenv global system 3.5
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
 
 install:
   - pip install -r test-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.5"
 
 install:
-  - pip install -r test-requirements.txt
+  - pip install tox-travis
 
 script:
   - tox


### PR DESCRIPTION
The travis build was failing due to missing versions of python in the build environment. This PR ensures that tox only attempts to execute against the current version of python in the travis matrix.